### PR TITLE
Fixes and enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -505,6 +505,9 @@ XMPP.prototype.__listeners = {
   groupbuddy: function (id, groupBuddy, state, statusText) {
     this.scope.debug('received groupbuddy event: ' + id, groupBuddy, state, statusText);
   },
+  groupchat: function(conference, id, message, stamp) {
+    this.scope.debug('received groupchat event: ' + conference, id, message, stamp);
+  },
   buddyCapabilities: function (id, capabilities) {
     this.scope.debug('received buddyCapabilities: ' + id, capabilities);
   },

--- a/index.js
+++ b/index.js
@@ -524,7 +524,7 @@ XMPP.prototype.__listeners = {
       object: {
         '@type': 'message',
         content: message,
-        id: nextId()
+        '@id': nextId()
       },
       published: new Date()
     });

--- a/index.js
+++ b/index.js
@@ -515,12 +515,17 @@ XMPP.prototype.__listeners = {
     this.scope.debug("received chat message from " + from);
     this.scope.send({
       '@type': 'send',
-      actor: { '@id': from },
+      actor: {
+        '@type': 'person',
+        '@id': from
+      },
       target: this.credentials.actor,
       object: {
+        '@type': 'message',
         content: message,
         id: nextId()
-      }
+      },
+      published: new Date()
     });
   },
   buddy: function (from, state, statusText) {

--- a/index.js
+++ b/index.js
@@ -506,7 +506,7 @@ XMPP.prototype.__listeners = {
   groupbuddy: function (id, groupBuddy, state, statusText) {
     this.scope.debug('received groupbuddy event: ' + id, groupBuddy, state, statusText);
   },
-  groupchat: function(conference, id, message, stamp) {
+  groupchat: function (conference, id, message, stamp) {
     this.scope.debug('received groupchat event: ' + conference, id, message, stamp);
   },
   buddyCapabilities: function (id, capabilities) {

--- a/index.js
+++ b/index.js
@@ -259,7 +259,8 @@ XMPP.prototype.send = function (job, done) {
     self.session.debug('sending message to ' + job.target['@id']);
     client.connection.send(
       job.target['@id'],
-      job.object.content
+      job.object.content,
+      job.target['@type'] === 'room'
     );
     done();
   });


### PR DESCRIPTION
This contains some fixes and enhancements.

* Use the third parameter on simple-xmpp's `send` message to indicate it's a groupchat message
* Listen to and log groupchat events
* Add more details to the message activity object

I couldn't find any timestamp or time related info in the message stanza, so I'm just using the current time for the `published` property when sending out the message activity. Better ideas for what to use here instead would be greatly appreciated.

As I haven't managed to actually join a MUC properly yet, I haven't actually seen the `groupchat` event so far. I just saw that simple-xmpp has code to emit it, but the platform wasn't handling it yet.