### PR TITLE
Send groupbuddy events

### DIFF
--- a/index.js
+++ b/index.js
@@ -505,6 +505,23 @@ XMPP.prototype.__listeners = {
   },
   groupbuddy: function (id, groupBuddy, state, statusText) {
     this.scope.debug('received groupbuddy event: ' + id, groupBuddy, state, statusText);
+    this.scope.send({
+      '@type': 'update',
+      actor: {
+        '@id': `${id}/${groupBuddy}`,
+        '@type': 'person',
+        displayName: groupBuddy
+      },
+      target: {
+        '@id': id,
+        '@type': 'room'
+      },
+      object: {
+        '@type': 'presence',
+        status: statusText,
+        presence: state
+      }
+    });
   },
   groupchat: function (room, from, message, stamp) {
     this.scope.debug('received groupchat event: ' + room, from, message, stamp);

--- a/test/incoming-data.js
+++ b/test/incoming-data.js
@@ -42,8 +42,9 @@ module.exports = [
     }
   },
   {
-    name: 'presence-4',
-    input: '<presence to="hermes@5apps.com/hyperchannel" from="test@muc.5apps.com/greg" xmlns:stream="http://etherx.jabber.org/streams"><c ver="d2rgtMP0QRwWPU4dGU5DEFz5ZmM=" hash="sha-1" node="http://conversations.im" xmlns="http://jabber.org/protocol/caps"/><x xmlns="http://jabber.org/protocol/muc#user"><item role="moderator" affiliation="owner"/></x></presence>',
+    name: 'groupbuddy event',
+    input: ['test@muc.5apps.com', 'greg', 'online', 'hey, wazzup?'],
+    handler: 'groupbuddy',
     output: {
       '@type': 'update',
       actor: {
@@ -57,7 +58,7 @@ module.exports = [
       },
       object: {
         '@type': 'presence',
-        status: null,
+        status: 'hey, wazzup?',
         presence: 'online'
       }
     }

--- a/test/incoming-data.js
+++ b/test/incoming-data.js
@@ -40,5 +40,26 @@ module.exports = [
         '@type': 'person'
       }
     }
+  },
+  {
+    name: 'presence-4',
+    input: '<presence to="hermes@5apps.com/hyperchannel" from="test@muc.5apps.com/greg" xmlns:stream="http://etherx.jabber.org/streams"><c ver="d2rgtMP0QRwWPU4dGU5DEFz5ZmM=" hash="sha-1" node="http://conversations.im" xmlns="http://jabber.org/protocol/caps"/><x xmlns="http://jabber.org/protocol/muc#user"><item role="moderator" affiliation="owner"/></x></presence>',
+    output: {
+      '@type': 'update',
+      actor: {
+        '@id': 'test@muc.5apps.com/greg',
+        '@type': 'person',
+        displayName: 'greg'
+      },
+      target: {
+        '@id': 'test@muc.5apps.com',
+        '@type': 'room'
+      },
+      object: {
+        '@type': 'presence',
+        status: null,
+        presence: 'online'
+      }
+    }
   }
 ];

--- a/test/xmpp-incoming-suite.js
+++ b/test/xmpp-incoming-suite.js
@@ -58,11 +58,16 @@ define(['require'], function (require) {
       tests.push({
         desc: '# incoming data: ' + entry.name,
         run: function (env, test) {
-          var stanza = ltx.parse(entry.input);
+          var inputParams;
+          if (typeof entry.input === 'string') {
+            inputParams = [ltx.parse(entry.input)]; // Stanza
+          } else {
+            inputParams = entry.input; // array of params
+          }
           env.session.callOnNext('send', function (msg) {
             test.assert(msg, entry.output);
           });
-          env.platform.__listeners.stanza.apply({ scope: env.session }, [ stanza ]);
+          env.platform.__listeners[entry.handler || "stanza"].apply({ scope: env.session }, inputParams);
         }
       })
     })


### PR DESCRIPTION
Groupbuddy events are presence updates for people in a chat room.

I tried adding a test for it by defining an input stanza and the expected output, but the test fails because of a timeout.

@silverbucket: any idea what I'm doing wrong there?