### PR TITLE
Fix sending query for getting MUC user list

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,7 +500,7 @@ XMPP.prototype.observe = function (job, credentials, done) {
     })
     stanza.c('query', { xmlns: 'http://jabber.org/protocol/disco#items' });
 
-    client.send(stanza);
+    client.conn.send(stanza);
 
     done();
   });

--- a/test/xmpp-suite.js
+++ b/test/xmpp-suite.js
@@ -246,12 +246,12 @@ define(['require'], function (require) {
         run: function (env, test) {
           const originalSend = env.xmpp.conn.send;
           let count = 0;
-          env.xmpp.send = new test.Stub(function(stanza) {
+          env.xmpp.conn.send = new test.Stub(function(stanza) {
             test.assertAnd(stanza.is('iq'), true);
             test.assertAnd(stanza.attrs.id, 'muc_id');
             test.assertAnd(stanza.attrs.from, 'xmpp:testingham@jabber.net');
             test.assertAnd(stanza.attrs.to, 'xmpp:partyroom@jabber.net');
-            env.xmpp.send = originalSend;
+            env.xmpp.conn.send = originalSend;
             count++;
             if (count === 2) { test.done(); }
           });


### PR DESCRIPTION
Fixes a bug introduced with 9f23f04a5dd that changed to use the wrong `send` function.

Please note that the merge target is the branch `feature/rework-connection-handling`.